### PR TITLE
fix: Using du instead of ls (ls format varies between OSes)

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -53,7 +53,8 @@ if [ $stage -le 0 ]; then
       rm -rf $corpus/$x
     done
   fi
-  find $corpus -name "*.wav" -exec ls -l {} \; | awk '{print $6" "$NF}' > $corpus/wav_all.lst
+  # du has a much more stable and defined output compared to ls
+  find $corpus -name "*.wav" -exec du -b {} \; > $corpus/wav_all.lst
   if [ "$(wc -l $corpus/wav_all.lst | awk '{print $1}')" -ne 87407 ];then
     echo "87407 wav files should be found here"
     exit


### PR DESCRIPTION
The output format of ls varies between OS distributions:
e.g. for centOS, the output of ls -l is:
```
$ ls -l run.sh
-rwxrwxr-x. 1 akshayc akshayc 8194 Feb 27 16:20 run.sh
```
So print $6 would have resulted in Feb and not the size of the file.

du ((man page)[http://linuxcommand.org/lc3_man_pages/du1.html]) is consistent across distributions.
